### PR TITLE
[CLOUD-1849] Bump from: EAP version to :1.6

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -1,6 +1,6 @@
 name: "jboss-kieserver-6/kieserver63-openshift"
 version: "1.5"
-from: "jboss-eap-6/eap64-openshift:1.5"
+from: "jboss-eap-6/eap64-openshift:1.6"
 description: "Base image supporting `jboss-decisionserver-6/decisionserver63-openshift`. This is not currently released or supported as an independent image for end-users."
 user: 185
 labels:


### PR DESCRIPTION
:1.6 was the version of EAP 6.4 that was built for Sprint 10, so
this image should now be based on it.