### PR TITLE
[CLOUD-2235] add jboss-kie-modules repo

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -133,6 +133,9 @@ modules:
           - git:
                   url: https://github.com/jboss-openshift/cct_module.git
                   ref: master
+          - git:
+                  url: https://github.com/jboss-container-images/jboss-kie-modules.git
+                  ref: master
       install:
           - name: os-kieserver-launch
           - name: os-kieserver-launch


### PR DESCRIPTION
Depends on
https://github.com/jboss-openshift/cct_module/pull/175
https://github.com/jboss-container-images/jboss-kie-modules/pull/1
