### PR TITLE
[CLOUD-2235] add reference to kie-modules

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -131,8 +131,11 @@ ports:
 modules:
       repositories:
           - git:
-                  url: https://github.com/jboss-openshift/cct_module.git
-                  ref: master
+              url: https://github.com/jboss-openshift/cct_module.git
+              ref: master
+          - git:
+              url: https://github.com/jboss-container-images/jboss-kie-modules.git
+              ref: master
       install:
           - name: os-kieserver-launch
           - name: os-kieserver-launch

--- a/image.yaml
+++ b/image.yaml
@@ -137,12 +137,12 @@ modules:
               url: https://github.com/jboss-container-images/jboss-kie-modules.git
               ref: master
       install:
-          - name: os-kieserver-launch
-          - name: os-kieserver-launch
-          - name: os-kieserver-probes
-          - name: os-kieserver-s2i
-          - name: os-kieserver-webapp
-          - name: os-kieserver-chmod
+          - name: os.kieserver.launch
+          - name: os.kieserver.launch
+          - name: os.kieserver.probes
+          - name: os.kieserver.s2i
+          - name: os.kieserver.webapp
+          - name: os.kieserver.chmod
           - name: os-java-run
           - name: jboss-maven
 packages:


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2235

KIE modules are moving repositories; make sure we reference the new location.

- [✓] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [✓] Pull Request contains link to the JIRA issue
- [✓] Pull Request contains description of the issue
- [✓] Pull Request does not include fixes for issues other than the main ticket
- [✓] Attached commits represent units of work and are properly formatted
- [✓] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [✓] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>