### PR TITLE
[CLOUD-2413] move image.yaml stuff to modules

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -147,12 +147,6 @@ modules:
           - name: os.kieserver.chmod
           - name: os-java-run
           - name: jboss-maven
-packages:
-      repositories:
-          - jboss-os
-          - jboss-rhscl
-      install:
-          - PyYAML
 artifacts:
     - path: jboss-bpmsuite-6.4.0.GA-deployable-eap6.x.zip
       md5: 5621266e64f6ae1d6740940ec279a1ff


### PR DESCRIPTION
Move material from image.yaml out to cct_modules.

https://issues.jboss.org/browse/CLOUD-2413