### PR TITLE
[KIECLOUD-207] update version references to 6.4.12.GA in 6.4.x images

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -8,9 +8,9 @@ labels:
     - name: "org.jboss.product"
       value: "kieserver"
     - name: "org.jboss.product.version"
-      value: "6.4.11.GA"
+      value: "6.4.12.GA"
     - name: "org.jboss.product.kieserver.version"
-      value: "6.4.11.GA"
+      value: "6.4.12.GA"
     - name: "com.redhat.component"
       value: "jboss-kieserver-6-kieserver64-openshift-container"
     - name: "io.k8s.description"
@@ -23,9 +23,9 @@ envs:
     - name: "JBOSS_PRODUCT"
       value: "kieserver"
     - name: "JBOSS_KIESERVER_VERSION"
-      value: "6.4.11.GA"
+      value: "6.4.12.GA"
     - name: "PRODUCT_VERSION"
-      value: "6.4.11.GA"
+      value: "6.4.12.GA"
 modules:
       repositories:
           - name: cct_module

--- a/modules/kieserver/module.yaml
+++ b/modules/kieserver/module.yaml
@@ -10,6 +10,11 @@ labels:
     - name: "io.openshift.s2i.scripts-url"
       value: "image:///usr/local/s2i"
 envs:
+    # TODO:
+    # 1. Update BPMSUITE_BASE_VERSION to 6.4.12.GA once we have a 6.4.12 version of jboss-bpmsuite-6.4.11.GA-deployable-eap6.x.zip
+    # 2. Update artifacts section below to 6.4.12, as well as references in cache-artifacts.sh
+    # 3. See if this patch can be removed: https://github.com/jboss-container-images/jboss-kie-modules/blob/master/os.kieserver.webapp/configure.sh#L64-L78
+    # 4. Remove this "TODO" section of 4 tasks
     - name: "BPMSUITE_BASE_VERSION"
       value: "6.4.11.GA"
       description: "BPM Suite base installation version."

--- a/tag-overrides.yaml
+++ b/tag-overrides.yaml
@@ -17,4 +17,4 @@ modules:
           - name: jboss-kie-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-kie-modules.git
-                  ref: rhpam-6.4.11.GA-1
+                  ref: rhpam-6.4.12.GA


### PR DESCRIPTION
[KIECLOUD-207] update version references to 6.4.12.GA in 6.4.x images
https://issues.jboss.org/browse/KIECLOUD-207

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject`, `[RHDM-XYZ] Subject` or `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
